### PR TITLE
Don't pick up unwanted files in tests

### DIFF
--- a/test/differential.sh
+++ b/test/differential.sh
@@ -16,6 +16,8 @@ setup() {
 
     CHECKTON_DIFF_BASE=$(git rev-parse HEAD)
     export CHECKTON_DIFF_BASE
+
+    export CHECKTON_INCLUDE_REGEX='^test/.*\.ya?ml$'
 }
 
 teardown() {


### PR DESCRIPTION
By default, differential checkton also picks up the scripts in .github/workflows/*.yaml, which can mess with tests. Make sure they only pick up test files

<!-- Briefly explain what the PR does and why. -->

### Checklist

* [ ] Add/update tests for your changes
* [ ] Update CHANGELOG.md if your changes are relevant to users (<https://keepachangelog.com/en/1.1.0/#how>)
