### PR TITLE
Avoid getting confused by new violations of the same type as existing ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A script nested inside another script (e.g. inside a heredoc string) no longer
   breaks the enclosing script
+- Introducing a ShellCheck violation into a file that already has a violation of
+  the same type could confuse Checkton, making it report the old violation instead
+  of the new one.
 
 ## [v0.1.0-alpha.2] - 2024-06-18
 

--- a/src/differential-checkton.sh
+++ b/src/differential-checkton.sh
@@ -147,6 +147,10 @@ checkton() {
     "${SCRIPTDIR}/checkton.py" "$@"
 }
 
+csgrep_embed() {
+    csgrep --mode=json --embed 1
+}
+
 main() {
     collect_file_pairs
 
@@ -167,7 +171,7 @@ main() {
         (
             at_ref "$BASE"
             dupe_renamed_and_copied_files
-            checkton "${all_files[@]}" > "$old_results"
+            checkton "${all_files[@]}" | csgrep_embed > "$old_results"
         )
     else
         touch "$old_results"
@@ -175,7 +179,7 @@ main() {
 
     (
         at_ref "$HEAD"
-        checkton "${new_files[@]}" > "$new_results"
+        checkton "${new_files[@]}" | csgrep_embed > "$new_results"
     )
 
     csdiff "$old_results" "$new_results"

--- a/test/differential.sh
+++ b/test/differential.sh
@@ -110,3 +110,8 @@ test_differential_checkton() {
     test_differential_checkton diff-disabled \
         "$R/patches/0001-Add-a-script-with-some-issues.patch"
 }
+
+@test "handling a new issue of the same type as one that's already present in the file" {
+    test_differential_checkton new-issue-of-same-type \
+        "$R/patches/0001-Add-another-unquoted-variable.patch"
+}

--- a/test/resources/differential/detected-copy/csdiff.json
+++ b/test/resources/differential/detected-copy/csdiff.json
@@ -4,6 +4,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "e07aec91f8a692a71da7d0dd3f8774357e95e64f",
             "key_event_idx": 0,
             "events": [
                 {
@@ -14,6 +15,13 @@
                     "event": "warning[SC3010]",
                     "message": "In POSIX sh, [[ ]] is undefined.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -21,6 +29,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "a0dbfd8e936506d64f96536a972f8e67e428ab77",
             "key_event_idx": 0,
             "events": [
                 {
@@ -31,6 +40,13 @@
                     "event": "warning[SC2050]",
                     "message": "This expression is constant. Did you forget the $ on a variable?",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -38,6 +54,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "e5d95fee317efc7ea546105d09f1a8ced5f54038",
             "key_event_idx": 0,
             "events": [
                 {
@@ -48,6 +65,13 @@
                     "event": "warning[SC3010]",
                     "message": "In POSIX sh, [[ ]] is undefined.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -55,6 +79,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "8877acfcffeed8d91b1e8b5936bc83b61bed0b92",
             "key_event_idx": 0,
             "events": [
                 {
@@ -65,6 +90,13 @@
                     "event": "warning[SC2050]",
                     "message": "This expression is constant. Did you forget the $ on a variable?",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         }

--- a/test/resources/differential/diff-disabled/csdiff.json
+++ b/test/resources/differential/diff-disabled/csdiff.json
@@ -4,6 +4,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "e07aec91f8a692a71da7d0dd3f8774357e95e64f",
             "key_event_idx": 0,
             "events": [
                 {
@@ -14,6 +15,13 @@
                     "event": "warning[SC3010]",
                     "message": "In POSIX sh, [[ ]] is undefined.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -21,6 +29,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "a0dbfd8e936506d64f96536a972f8e67e428ab77",
             "key_event_idx": 0,
             "events": [
                 {
@@ -31,6 +40,13 @@
                     "event": "warning[SC2050]",
                     "message": "This expression is constant. Did you forget the $ on a variable?",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -38,6 +54,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "8a744b663ce36a3d31f7ff5171212082039783df",
             "key_event_idx": 0,
             "events": [
                 {
@@ -48,6 +65,13 @@
                     "event": "error[SC2096]",
                     "message": "On most OS, shebangs can only specify a single parameter.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   34|->         #!/bin/bash -e -u -o pipefail",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -55,6 +79,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "169d75b8bc451acb8bc08667ca76eb11bab15712",
             "key_event_idx": 0,
             "events": [
                 {
@@ -65,6 +90,13 @@
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   29|->         eval $SCRIPT",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -72,6 +104,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "980692cf15515f28eedb92c5057f9ad46c8bd896",
             "key_event_idx": 0,
             "events": [
                 {
@@ -82,6 +115,13 @@
                     "event": "warning[SC2154]",
                     "message": "watery_tart is referenced but not assigned.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   27|->             echo \"You can't expect to wield supreme executive power just 'cause some $watery_tart threw a sword at you!\"",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -89,6 +129,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "e3d4958b1d02857927f75149c080822cddeb9da6",
             "key_event_idx": 0,
             "events": [
                 {
@@ -99,6 +140,13 @@
                     "event": "warning[SC2091]",
                     "message": "Remove surrounding $() to avoid executing output (or use eval if intentional).",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "    9|->   $(bash script.sh)",
+                    "verbosity_level": 1
                 }
             ]
         }

--- a/test/resources/differential/exclude-pattern/csdiff.json
+++ b/test/resources/differential/exclude-pattern/csdiff.json
@@ -4,6 +4,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "e07aec91f8a692a71da7d0dd3f8774357e95e64f",
             "key_event_idx": 0,
             "events": [
                 {
@@ -14,6 +15,13 @@
                     "event": "warning[SC3010]",
                     "message": "In POSIX sh, [[ ]] is undefined.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -21,6 +29,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "a0dbfd8e936506d64f96536a972f8e67e428ab77",
             "key_event_idx": 0,
             "events": [
                 {
@@ -31,6 +40,13 @@
                     "event": "warning[SC2050]",
                     "message": "This expression is constant. Did you forget the $ on a variable?",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         }

--- a/test/resources/differential/include-pattern/csdiff.json
+++ b/test/resources/differential/include-pattern/csdiff.json
@@ -4,6 +4,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "e5d95fee317efc7ea546105d09f1a8ced5f54038",
             "key_event_idx": 0,
             "events": [
                 {
@@ -14,6 +15,13 @@
                     "event": "warning[SC3010]",
                     "message": "In POSIX sh, [[ ]] is undefined.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -21,6 +29,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "8877acfcffeed8d91b1e8b5936bc83b61bed0b92",
             "key_event_idx": 0,
             "events": [
                 {
@@ -31,6 +40,13 @@
                     "event": "warning[SC2050]",
                     "message": "This expression is constant. Did you forget the $ on a variable?",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         }

--- a/test/resources/differential/new-issue-of-same-type/csdiff.json
+++ b/test/resources/differential/new-issue-of-same-type/csdiff.json
@@ -4,16 +4,24 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "bb7ce503aa882be0504f50e12ccca66c2119129f",
             "key_event_idx": 0,
             "events": [
                 {
                     "file_name": "test/resources/files-to-check/tektontask.yaml",
-                    "line": 29,
+                    "line": 36,
                     "column": 14,
-                    "h_size": 7,
+                    "h_size": 3,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   36|->         echo $HI",
+                    "verbosity_level": 1
                 }
             ]
         }

--- a/test/resources/differential/new-issue-of-same-type/csdiff.json
+++ b/test/resources/differential/new-issue-of-same-type/csdiff.json
@@ -1,0 +1,21 @@
+{
+    "defects": [
+        {
+            "checker": "SHELLCHECK_WARNING",
+            "language": "shell",
+            "tool": "shellcheck",
+            "key_event_idx": 0,
+            "events": [
+                {
+                    "file_name": "test/resources/files-to-check/tektontask.yaml",
+                    "line": 29,
+                    "column": 14,
+                    "h_size": 7,
+                    "event": "info[SC2086]",
+                    "message": "Double quote to prevent globbing and word splitting.",
+                    "verbosity_level": 0
+                }
+            ]
+        }
+    ]
+}

--- a/test/resources/differential/new-issue-of-same-type/csgrep.embed4.txt
+++ b/test/resources/differential/new-issue-of-same-type/csgrep.embed4.txt
@@ -1,0 +1,9 @@
+Error: SHELLCHECK_WARNING:
+test/resources/files-to-check/tektontask.yaml:29:14: info[SC2086]: Double quote to prevent globbing and word splitting.
+#   26|   
+#   27|               echo "You can't expect to wield supreme executive power just 'cause some $watery_tart threw a sword at you!"
+#   28|         script: |+
+#   29|->         eval $SCRIPT
+#   30|   
+#   31|       - name: script-with-broken-shebang
+#   32|         image: foo:latest

--- a/test/resources/differential/new-issue-of-same-type/csgrep.embed4.txt
+++ b/test/resources/differential/new-issue-of-same-type/csgrep.embed4.txt
@@ -1,9 +1,6 @@
 Error: SHELLCHECK_WARNING:
-test/resources/files-to-check/tektontask.yaml:29:14: info[SC2086]: Double quote to prevent globbing and word splitting.
-#   26|   
-#   27|               echo "You can't expect to wield supreme executive power just 'cause some $watery_tart threw a sword at you!"
-#   28|         script: |+
-#   29|->         eval $SCRIPT
-#   30|   
-#   31|       - name: script-with-broken-shebang
-#   32|         image: foo:latest
+test/resources/files-to-check/tektontask.yaml:36:14: info[SC2086]: Double quote to prevent globbing and word splitting.
+#   33|         script: |-
+#   34|           #!/bin/bash -e -u -o pipefail
+#   35|           echo "I mean, if I went around saying I was an emperor just because some moistened bint had lobbed a scimitar at me, they'd put me away!"
+#   36|->         echo $HI

--- a/test/resources/differential/new-issue-of-same-type/sarif-fmt.txt
+++ b/test/resources/differential/new-issue-of-same-type/sarif-fmt.txt
@@ -1,0 +1,7 @@
+warning: Double quote to prevent globbing and word splitting.
+   ┌─ test/resources/files-to-check/tektontask.yaml:29:14
+   │
+29 │         eval $SCRIPT
+   │              ^^^^^^^
+
+warning: 1 warnings emitted

--- a/test/resources/differential/new-issue-of-same-type/sarif-fmt.txt
+++ b/test/resources/differential/new-issue-of-same-type/sarif-fmt.txt
@@ -1,7 +1,7 @@
 warning: Double quote to prevent globbing and word splitting.
-   ┌─ test/resources/files-to-check/tektontask.yaml:29:14
+   ┌─ test/resources/files-to-check/tektontask.yaml:36:14
    │
-29 │         eval $SCRIPT
-   │              ^^^^^^^
+36 │         echo $HI
+   │              ^^^
 
 warning: 1 warnings emitted

--- a/test/resources/differential/new-script/csdiff.json
+++ b/test/resources/differential/new-script/csdiff.json
@@ -4,6 +4,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "e07aec91f8a692a71da7d0dd3f8774357e95e64f",
             "key_event_idx": 0,
             "events": [
                 {
@@ -14,6 +15,13 @@
                     "event": "warning[SC3010]",
                     "message": "In POSIX sh, [[ ]] is undefined.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -21,6 +29,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "a0dbfd8e936506d64f96536a972f8e67e428ab77",
             "key_event_idx": 0,
             "events": [
                 {
@@ -31,6 +40,13 @@
                     "event": "warning[SC2050]",
                     "message": "This expression is constant. Did you forget the $ on a variable?",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         }

--- a/test/resources/differential/old-base/csdiff.json
+++ b/test/resources/differential/old-base/csdiff.json
@@ -4,6 +4,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "8a744b663ce36a3d31f7ff5171212082039783df",
             "key_event_idx": 0,
             "events": [
                 {
@@ -14,6 +15,13 @@
                     "event": "error[SC2096]",
                     "message": "On most OS, shebangs can only specify a single parameter.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   34|->         #!/bin/bash -e -u -o pipefail",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -21,6 +29,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "169d75b8bc451acb8bc08667ca76eb11bab15712",
             "key_event_idx": 0,
             "events": [
                 {
@@ -31,6 +40,13 @@
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   29|->         eval $SCRIPT",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -38,6 +54,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "980692cf15515f28eedb92c5057f9ad46c8bd896",
             "key_event_idx": 0,
             "events": [
                 {
@@ -48,6 +65,13 @@
                     "event": "warning[SC2154]",
                     "message": "watery_tart is referenced but not assigned.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   27|->             echo \"You can't expect to wield supreme executive power just 'cause some $watery_tart threw a sword at you!\"",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -55,6 +79,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "e3d4958b1d02857927f75149c080822cddeb9da6",
             "key_event_idx": 0,
             "events": [
                 {
@@ -65,6 +90,13 @@
                     "event": "warning[SC2091]",
                     "message": "Remove surrounding $() to avoid executing output (or use eval if intentional).",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "    9|->   $(bash script.sh)",
+                    "verbosity_level": 1
                 }
             ]
         }

--- a/test/resources/differential/renamed/csdiff.json
+++ b/test/resources/differential/renamed/csdiff.json
@@ -4,6 +4,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "e5d95fee317efc7ea546105d09f1a8ced5f54038",
             "key_event_idx": 0,
             "events": [
                 {
@@ -14,6 +15,13 @@
                     "event": "warning[SC3010]",
                     "message": "In POSIX sh, [[ ]] is undefined.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -21,6 +29,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "8877acfcffeed8d91b1e8b5936bc83b61bed0b92",
             "key_event_idx": 0,
             "events": [
                 {
@@ -31,6 +40,13 @@
                     "event": "warning[SC2050]",
                     "message": "This expression is constant. Did you forget the $ on a variable?",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         }

--- a/test/resources/differential/undetected-copy/csdiff.json
+++ b/test/resources/differential/undetected-copy/csdiff.json
@@ -4,6 +4,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "e07aec91f8a692a71da7d0dd3f8774357e95e64f",
             "key_event_idx": 0,
             "events": [
                 {
@@ -14,6 +15,13 @@
                     "event": "warning[SC3010]",
                     "message": "In POSIX sh, [[ ]] is undefined.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -21,6 +29,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "a0dbfd8e936506d64f96536a972f8e67e428ab77",
             "key_event_idx": 0,
             "events": [
                 {
@@ -31,6 +40,13 @@
                     "event": "warning[SC2050]",
                     "message": "This expression is constant. Did you forget the $ on a variable?",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -38,6 +54,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "e5d95fee317efc7ea546105d09f1a8ced5f54038",
             "key_event_idx": 0,
             "events": [
                 {
@@ -48,6 +65,13 @@
                     "event": "warning[SC3010]",
                     "message": "In POSIX sh, [[ ]] is undefined.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -55,6 +79,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "8877acfcffeed8d91b1e8b5936bc83b61bed0b92",
             "key_event_idx": 0,
             "events": [
                 {
@@ -65,6 +90,13 @@
                     "event": "warning[SC2050]",
                     "message": "This expression is constant. Did you forget the $ on a variable?",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -72,6 +104,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "d6c6e62f53afc94a13a0476bae48a82a2599bf07",
             "key_event_idx": 0,
             "events": [
                 {
@@ -82,6 +115,13 @@
                     "event": "error[SC2096]",
                     "message": "On most OS, shebangs can only specify a single parameter.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   34|->         #!/bin/bash -e -u -o pipefail",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -89,6 +129,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "55c77778e5dacd2e739eb87732bfa8f8f091751d",
             "key_event_idx": 0,
             "events": [
                 {
@@ -99,6 +140,13 @@
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   29|->         eval $SCRIPT",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -106,6 +154,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "c2dda3301c240486855f3ed2bf16b47072959ed6",
             "key_event_idx": 0,
             "events": [
                 {
@@ -116,6 +165,13 @@
                     "event": "warning[SC2154]",
                     "message": "watery_tart is referenced but not assigned.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   27|->             echo \"You can't expect to wield supreme executive power just 'cause some $watery_tart threw a sword at you!\"",
+                    "verbosity_level": 1
                 }
             ]
         }

--- a/test/resources/differential/undetected-rename/csdiff.json
+++ b/test/resources/differential/undetected-rename/csdiff.json
@@ -4,6 +4,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "e5d95fee317efc7ea546105d09f1a8ced5f54038",
             "key_event_idx": 0,
             "events": [
                 {
@@ -14,6 +15,13 @@
                     "event": "warning[SC3010]",
                     "message": "In POSIX sh, [[ ]] is undefined.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -21,6 +29,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "8877acfcffeed8d91b1e8b5936bc83b61bed0b92",
             "key_event_idx": 0,
             "events": [
                 {
@@ -31,6 +40,13 @@
                     "event": "warning[SC2050]",
                     "message": "This expression is constant. Did you forget the $ on a variable?",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   40|->         if [[ violence = 'inherent in the system' ]]; then",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -38,6 +54,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "d6c6e62f53afc94a13a0476bae48a82a2599bf07",
             "key_event_idx": 0,
             "events": [
                 {
@@ -48,6 +65,13 @@
                     "event": "error[SC2096]",
                     "message": "On most OS, shebangs can only specify a single parameter.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   34|->         #!/bin/bash -e -u -o pipefail",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -55,6 +79,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "55c77778e5dacd2e739eb87732bfa8f8f091751d",
             "key_event_idx": 0,
             "events": [
                 {
@@ -65,6 +90,13 @@
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   29|->         eval $SCRIPT",
+                    "verbosity_level": 1
                 }
             ]
         },
@@ -72,6 +104,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
+            "hash_v1": "c2dda3301c240486855f3ed2bf16b47072959ed6",
             "key_event_idx": 0,
             "events": [
                 {
@@ -82,6 +115,13 @@
                     "event": "warning[SC2154]",
                     "message": "watery_tart is referenced but not assigned.",
                     "verbosity_level": 0
+                },
+                {
+                    "file_name": "",
+                    "line": 0,
+                    "event": "#",
+                    "message": "   27|->             echo \"You can't expect to wield supreme executive power just 'cause some $watery_tart threw a sword at you!\"",
+                    "verbosity_level": 1
                 }
             ]
         }

--- a/test/resources/patches/0001-Add-a-script-with-some-issues.patch
+++ b/test/resources/patches/0001-Add-a-script-with-some-issues.patch
@@ -1,6 +1,6 @@
-From 168073bfe75b5ef7d737c5a0ba0fdb7c5ec41b49 Mon Sep 17 00:00:00 2001
+From deadbeef01deadbeef02deadbeef03deadbeef04 Mon Sep 17 00:00:00 2001
 From: Checkton Patcher <checkton-patcher@noreply.org>
-Date: Thu, 20 Jun 2024 16:01:21 +0200
+Date: Thu, 20 Jun 2024 16:00:00 +0000
 Subject: [PATCH] Add a script with some issues
 
 ---

--- a/test/resources/patches/0001-Add-another-unquoted-variable.patch
+++ b/test/resources/patches/0001-Add-another-unquoted-variable.patch
@@ -1,0 +1,21 @@
+From deadbeef01deadbeef02deadbeef03deadbeef04 Mon Sep 17 00:00:00 2001
+From: Checkton Patcher <checkton-patcher@noreply.org>
+Date: Thu, 20 Jun 2024 16:00:00 +0000
+Subject: [PATCH] Add another unquoted variable
+
+---
+ test/resources/files-to-check/tektontask.yaml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/test/resources/files-to-check/tektontask.yaml b/test/resources/files-to-check/tektontask.yaml
+index 24b74e3..150a030 100644
+--- a/test/resources/files-to-check/tektontask.yaml
++++ b/test/resources/files-to-check/tektontask.yaml
+@@ -33,3 +33,4 @@ spec:
+       script: |-
+         #!/bin/bash -e -u -o pipefail
+         echo "I mean, if I went around saying I was an emperor just because some moistened bint had lobbed a scimitar at me, they'd put me away!"
++        echo $HI
+-- 
+2.45.1
+

--- a/test/resources/patches/0001-Copy-tektontask-to-cooltask.patch
+++ b/test/resources/patches/0001-Copy-tektontask-to-cooltask.patch
@@ -1,6 +1,6 @@
-From 5a61cf02226a8d97a8ae19f8a67b316cccbefc02 Mon Sep 17 00:00:00 2001
+From deadbeef01deadbeef02deadbeef03deadbeef04 Mon Sep 17 00:00:00 2001
 From: Checkton Patcher <checkton-patcher@noreply.org>
-Date: Thu, 20 Jun 2024 16:01:22 +0200
+Date: Thu, 20 Jun 2024 16:00:00 +0000
 Subject: [PATCH] Copy tektontask to cooltask
 
 ---

--- a/test/resources/patches/0001-Rename-tektontask-to-cooltask.patch
+++ b/test/resources/patches/0001-Rename-tektontask-to-cooltask.patch
@@ -1,6 +1,6 @@
-From fd54d9f8a8dfdca57d991fc36cfa4fc2ddf3b625 Mon Sep 17 00:00:00 2001
+From deadbeef01deadbeef02deadbeef03deadbeef04 Mon Sep 17 00:00:00 2001
 From: Checkton Patcher <checkton-patcher@noreply.org>
-Date: Thu, 20 Jun 2024 16:01:21 +0200
+Date: Thu, 20 Jun 2024 16:00:00 +0000
 Subject: [PATCH] Rename tektontask to cooltask
 
 ---

--- a/test/resources/patches/generate.sh
+++ b/test/resources/patches/generate.sh
@@ -22,21 +22,28 @@ gen_patches() {
         fi
 EOF
 
-    commit_args=(--author "Checkton Patcher <checkton-patcher@noreply.org>")
-
     git add "$tektontask"
-    git commit "${commit_args[@]}" -m "Add a script with some issues"
-    git format-patch -1 -o test/resources/patches
+    _commit_and_save_patch "Add a script with some issues"
 
     local cooltask=${tektontask%/*}/cooltask.yaml
     git mv "$tektontask" "$cooltask"
-    git commit "${commit_args[@]}" -m "Rename tektontask to cooltask"
-    git format-patch -1 -o test/resources/patches
+    _commit_and_save_patch "Rename tektontask to cooltask"
 
     git reset HEAD^
     git checkout -- "$tektontask"
     git add "$cooltask"
-    git commit "${commit_args[@]}" -m "Copy tektontask to cooltask"
+    _commit_and_save_patch "Copy tektontask to cooltask"
+
+    sed -i 's/^From [0-9a-f]*/From deadbeef01deadbeef02deadbeef03deadbeef04/' \
+        test/resources/patches/*.patch
+}
+
+_commit_and_save_patch() {
+    local commit_args=(
+        --author "Checkton Patcher <checkton-patcher@noreply.org>"
+        --date "Thu, 20 Jun 2024 16:00:00 +0000"
+    )
+    git commit "${commit_args[@]}" -m "$1"
     git format-patch -1 -o test/resources/patches
 }
 

--- a/test/resources/patches/generate.sh
+++ b/test/resources/patches/generate.sh
@@ -24,6 +24,8 @@ EOF
 
     git add "$tektontask"
     _commit_and_save_patch "Add a script with some issues"
+    local add_script_ref
+    add_script_ref=$(git rev-parse HEAD)
 
     local cooltask=${tektontask%/*}/cooltask.yaml
     git mv "$tektontask" "$cooltask"
@@ -33,6 +35,11 @@ EOF
     git checkout -- "$tektontask"
     git add "$cooltask"
     _commit_and_save_patch "Copy tektontask to cooltask"
+
+    git revert --no-edit "$add_script_ref"
+    echo "        echo \$HI" >> "$tektontask"
+    git add "$tektontask"
+    _commit_and_save_patch "Add another unquoted variable"
 
     sed -i 's/^From [0-9a-f]*/From deadbeef01deadbeef02deadbeef03deadbeef04/' \
         test/resources/patches/*.patch


### PR DESCRIPTION
Introducing a ShellCheck violation into a file that already has a violation of the same type could confuse Checkton, making it report the old violation instead of the new one.

Fix this by embedding line content into the files that are `csdiff`-ed at the end

### Checklist

* [ ] Add/update tests for your changes
* [ ] Update CHANGELOG.md if your changes are relevant to users (<https://keepachangelog.com/en/1.1.0/#how>)
