### PR TITLE
Fix copying of renamed/copied files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-*Nothing yet.*
+### Fixed
+
+- Moving/copying a file into a directory that did not exist in the base ref would
+  cause Checkton to fail when trying to copy the file
 
 ## [v0.1.1] - 2024-06-21
 

--- a/src/differential-checkton.sh
+++ b/src/differential-checkton.sh
@@ -138,6 +138,7 @@ dupe_renamed_and_copied_files() {
     for current_name in "${!FILE_PAIRS[@]}"; do
         old_name=${FILE_PAIRS[$current_name]}
         if [[ -n "$old_name" && "$old_name" != "$current_name" && ! -e "$current_name" ]]; then
+            mkdir -p "$(dirname "$current_name")"
             cp "$old_name" "$current_name"
         fi
     done

--- a/test/resources/differential/detected-copy/csdiff.json
+++ b/test/resources/differential/detected-copy/csdiff.json
@@ -54,11 +54,11 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
-            "hash_v1": "e5d95fee317efc7ea546105d09f1a8ced5f54038",
+            "hash_v1": "cb9f1c3234e99556b69af0685544c56ae9bdf46e",
             "key_event_idx": 0,
             "events": [
                 {
-                    "file_name": "test/resources/files-to-check/cooltask.yaml",
+                    "file_name": "test/resources/files-to-check/subdir/cooltask.yaml",
                     "line": 40,
                     "column": 12,
                     "h_size": 41,
@@ -79,11 +79,11 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
-            "hash_v1": "8877acfcffeed8d91b1e8b5936bc83b61bed0b92",
+            "hash_v1": "1046816acc2a9859ec6b631efef4825a89b3fe15",
             "key_event_idx": 0,
             "events": [
                 {
-                    "file_name": "test/resources/files-to-check/cooltask.yaml",
+                    "file_name": "test/resources/files-to-check/subdir/cooltask.yaml",
                     "line": 40,
                     "column": 24,
                     "h_size": 1,

--- a/test/resources/differential/detected-copy/csgrep.embed4.txt
+++ b/test/resources/differential/detected-copy/csgrep.embed4.txt
@@ -17,7 +17,7 @@ test/resources/files-to-check/tektontask.yaml:40:24: warning[SC2050]: This expre
 #   42|           fi
 
 Error: SHELLCHECK_WARNING:
-test/resources/files-to-check/cooltask.yaml:40:12: warning[SC3010]: In POSIX sh, [[ ]] is undefined.
+test/resources/files-to-check/subdir/cooltask.yaml:40:12: warning[SC3010]: In POSIX sh, [[ ]] is undefined.
 #   37|       - name: new-script
 #   38|         image: foo:latest
 #   39|         script: |
@@ -26,7 +26,7 @@ test/resources/files-to-check/cooltask.yaml:40:12: warning[SC3010]: In POSIX sh,
 #   42|           fi
 
 Error: SHELLCHECK_WARNING:
-test/resources/files-to-check/cooltask.yaml:40:24: warning[SC2050]: This expression is constant. Did you forget the $ on a variable?
+test/resources/files-to-check/subdir/cooltask.yaml:40:24: warning[SC2050]: This expression is constant. Did you forget the $ on a variable?
 #   37|       - name: new-script
 #   38|         image: foo:latest
 #   39|         script: |

--- a/test/resources/differential/detected-copy/sarif-fmt.txt
+++ b/test/resources/differential/detected-copy/sarif-fmt.txt
@@ -11,13 +11,13 @@ warning: This expression is constant. Did you forget the $ on a variable?
    │                        ^
 
 warning: In POSIX sh, [[ ]] is undefined.
-   ┌─ test/resources/files-to-check/cooltask.yaml:40:12
+   ┌─ test/resources/files-to-check/subdir/cooltask.yaml:40:12
    │
 40 │         if [[ violence = 'inherent in the system' ]]; then
    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: This expression is constant. Did you forget the $ on a variable?
-   ┌─ test/resources/files-to-check/cooltask.yaml:40:24
+   ┌─ test/resources/files-to-check/subdir/cooltask.yaml:40:24
    │
 40 │         if [[ violence = 'inherent in the system' ]]; then
    │                        ^

--- a/test/resources/differential/include-pattern/csdiff.json
+++ b/test/resources/differential/include-pattern/csdiff.json
@@ -4,11 +4,11 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
-            "hash_v1": "e5d95fee317efc7ea546105d09f1a8ced5f54038",
+            "hash_v1": "cb9f1c3234e99556b69af0685544c56ae9bdf46e",
             "key_event_idx": 0,
             "events": [
                 {
-                    "file_name": "test/resources/files-to-check/cooltask.yaml",
+                    "file_name": "test/resources/files-to-check/subdir/cooltask.yaml",
                     "line": 40,
                     "column": 12,
                     "h_size": 41,
@@ -29,11 +29,11 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
-            "hash_v1": "8877acfcffeed8d91b1e8b5936bc83b61bed0b92",
+            "hash_v1": "1046816acc2a9859ec6b631efef4825a89b3fe15",
             "key_event_idx": 0,
             "events": [
                 {
-                    "file_name": "test/resources/files-to-check/cooltask.yaml",
+                    "file_name": "test/resources/files-to-check/subdir/cooltask.yaml",
                     "line": 40,
                     "column": 24,
                     "h_size": 1,

--- a/test/resources/differential/include-pattern/csgrep.embed4.txt
+++ b/test/resources/differential/include-pattern/csgrep.embed4.txt
@@ -1,5 +1,5 @@
 Error: SHELLCHECK_WARNING:
-test/resources/files-to-check/cooltask.yaml:40:12: warning[SC3010]: In POSIX sh, [[ ]] is undefined.
+test/resources/files-to-check/subdir/cooltask.yaml:40:12: warning[SC3010]: In POSIX sh, [[ ]] is undefined.
 #   37|       - name: new-script
 #   38|         image: foo:latest
 #   39|         script: |
@@ -8,7 +8,7 @@ test/resources/files-to-check/cooltask.yaml:40:12: warning[SC3010]: In POSIX sh,
 #   42|           fi
 
 Error: SHELLCHECK_WARNING:
-test/resources/files-to-check/cooltask.yaml:40:24: warning[SC2050]: This expression is constant. Did you forget the $ on a variable?
+test/resources/files-to-check/subdir/cooltask.yaml:40:24: warning[SC2050]: This expression is constant. Did you forget the $ on a variable?
 #   37|       - name: new-script
 #   38|         image: foo:latest
 #   39|         script: |

--- a/test/resources/differential/include-pattern/sarif-fmt.txt
+++ b/test/resources/differential/include-pattern/sarif-fmt.txt
@@ -1,11 +1,11 @@
 warning: In POSIX sh, [[ ]] is undefined.
-   ┌─ test/resources/files-to-check/cooltask.yaml:40:12
+   ┌─ test/resources/files-to-check/subdir/cooltask.yaml:40:12
    │
 40 │         if [[ violence = 'inherent in the system' ]]; then
    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: This expression is constant. Did you forget the $ on a variable?
-   ┌─ test/resources/files-to-check/cooltask.yaml:40:24
+   ┌─ test/resources/files-to-check/subdir/cooltask.yaml:40:24
    │
 40 │         if [[ violence = 'inherent in the system' ]]; then
    │                        ^

--- a/test/resources/differential/undetected-copy/csdiff.json
+++ b/test/resources/differential/undetected-copy/csdiff.json
@@ -54,11 +54,11 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
-            "hash_v1": "e5d95fee317efc7ea546105d09f1a8ced5f54038",
+            "hash_v1": "cb9f1c3234e99556b69af0685544c56ae9bdf46e",
             "key_event_idx": 0,
             "events": [
                 {
-                    "file_name": "test/resources/files-to-check/cooltask.yaml",
+                    "file_name": "test/resources/files-to-check/subdir/cooltask.yaml",
                     "line": 40,
                     "column": 12,
                     "h_size": 41,
@@ -79,11 +79,11 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
-            "hash_v1": "8877acfcffeed8d91b1e8b5936bc83b61bed0b92",
+            "hash_v1": "1046816acc2a9859ec6b631efef4825a89b3fe15",
             "key_event_idx": 0,
             "events": [
                 {
-                    "file_name": "test/resources/files-to-check/cooltask.yaml",
+                    "file_name": "test/resources/files-to-check/subdir/cooltask.yaml",
                     "line": 40,
                     "column": 24,
                     "h_size": 1,
@@ -104,11 +104,11 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
-            "hash_v1": "d6c6e62f53afc94a13a0476bae48a82a2599bf07",
+            "hash_v1": "c60c157e478910f61a8b552e3c02df87e8ab92ad",
             "key_event_idx": 0,
             "events": [
                 {
-                    "file_name": "test/resources/files-to-check/cooltask.yaml",
+                    "file_name": "test/resources/files-to-check/subdir/cooltask.yaml",
                     "line": 34,
                     "column": 9,
                     "h_size": 29,
@@ -129,11 +129,11 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
-            "hash_v1": "55c77778e5dacd2e739eb87732bfa8f8f091751d",
+            "hash_v1": "2d1ed2587276ee0eac3f2cef75562650a9e4f4ba",
             "key_event_idx": 0,
             "events": [
                 {
-                    "file_name": "test/resources/files-to-check/cooltask.yaml",
+                    "file_name": "test/resources/files-to-check/subdir/cooltask.yaml",
                     "line": 29,
                     "column": 14,
                     "h_size": 7,
@@ -154,11 +154,11 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
-            "hash_v1": "c2dda3301c240486855f3ed2bf16b47072959ed6",
+            "hash_v1": "7895d64287e3c85f9bbcb8bc87d9f9843b0da82d",
             "key_event_idx": 0,
             "events": [
                 {
-                    "file_name": "test/resources/files-to-check/cooltask.yaml",
+                    "file_name": "test/resources/files-to-check/subdir/cooltask.yaml",
                     "line": 27,
                     "column": 86,
                     "h_size": 12,

--- a/test/resources/differential/undetected-copy/csgrep.embed4.txt
+++ b/test/resources/differential/undetected-copy/csgrep.embed4.txt
@@ -17,7 +17,7 @@ test/resources/files-to-check/tektontask.yaml:40:24: warning[SC2050]: This expre
 #   42|           fi
 
 Error: SHELLCHECK_WARNING:
-test/resources/files-to-check/cooltask.yaml:40:12: warning[SC3010]: In POSIX sh, [[ ]] is undefined.
+test/resources/files-to-check/subdir/cooltask.yaml:40:12: warning[SC3010]: In POSIX sh, [[ ]] is undefined.
 #   37|       - name: new-script
 #   38|         image: foo:latest
 #   39|         script: |
@@ -26,7 +26,7 @@ test/resources/files-to-check/cooltask.yaml:40:12: warning[SC3010]: In POSIX sh,
 #   42|           fi
 
 Error: SHELLCHECK_WARNING:
-test/resources/files-to-check/cooltask.yaml:40:24: warning[SC2050]: This expression is constant. Did you forget the $ on a variable?
+test/resources/files-to-check/subdir/cooltask.yaml:40:24: warning[SC2050]: This expression is constant. Did you forget the $ on a variable?
 #   37|       - name: new-script
 #   38|         image: foo:latest
 #   39|         script: |
@@ -35,7 +35,7 @@ test/resources/files-to-check/cooltask.yaml:40:24: warning[SC2050]: This express
 #   42|           fi
 
 Error: SHELLCHECK_WARNING:
-test/resources/files-to-check/cooltask.yaml:34:9: error[SC2096]: On most OS, shebangs can only specify a single parameter.
+test/resources/files-to-check/subdir/cooltask.yaml:34:9: error[SC2096]: On most OS, shebangs can only specify a single parameter.
 #   31|       - name: script-with-broken-shebang
 #   32|         image: foo:latest
 #   33|         script: |-
@@ -45,7 +45,7 @@ test/resources/files-to-check/cooltask.yaml:34:9: error[SC2096]: On most OS, she
 #   37|       - name: new-script
 
 Error: SHELLCHECK_WARNING:
-test/resources/files-to-check/cooltask.yaml:29:14: info[SC2086]: Double quote to prevent globbing and word splitting.
+test/resources/files-to-check/subdir/cooltask.yaml:29:14: info[SC2086]: Double quote to prevent globbing and word splitting.
 #   26|   
 #   27|               echo "You can't expect to wield supreme executive power just 'cause some $watery_tart threw a sword at you!"
 #   28|         script: |+
@@ -55,7 +55,7 @@ test/resources/files-to-check/cooltask.yaml:29:14: info[SC2086]: Double quote to
 #   32|         image: foo:latest
 
 Error: SHELLCHECK_WARNING:
-test/resources/files-to-check/cooltask.yaml:27:86: warning[SC2154]: watery_tart is referenced but not assigned.
+test/resources/files-to-check/subdir/cooltask.yaml:27:86: warning[SC2154]: watery_tart is referenced but not assigned.
 #   24|               #!/usr/bin/env bash
 #   25|               set -euo pipefail
 #   26|   

--- a/test/resources/differential/undetected-copy/sarif-fmt.txt
+++ b/test/resources/differential/undetected-copy/sarif-fmt.txt
@@ -11,31 +11,31 @@ warning: This expression is constant. Did you forget the $ on a variable?
    │                        ^
 
 warning: In POSIX sh, [[ ]] is undefined.
-   ┌─ test/resources/files-to-check/cooltask.yaml:40:12
+   ┌─ test/resources/files-to-check/subdir/cooltask.yaml:40:12
    │
 40 │         if [[ violence = 'inherent in the system' ]]; then
    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: This expression is constant. Did you forget the $ on a variable?
-   ┌─ test/resources/files-to-check/cooltask.yaml:40:24
+   ┌─ test/resources/files-to-check/subdir/cooltask.yaml:40:24
    │
 40 │         if [[ violence = 'inherent in the system' ]]; then
    │                        ^
 
 error: On most OS, shebangs can only specify a single parameter.
-   ┌─ test/resources/files-to-check/cooltask.yaml:34:9
+   ┌─ test/resources/files-to-check/subdir/cooltask.yaml:34:9
    │
 34 │         #!/bin/bash -e -u -o pipefail
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: Double quote to prevent globbing and word splitting.
-   ┌─ test/resources/files-to-check/cooltask.yaml:29:14
+   ┌─ test/resources/files-to-check/subdir/cooltask.yaml:29:14
    │
 29 │         eval $SCRIPT
    │              ^^^^^^^
 
 warning: watery_tart is referenced but not assigned.
-   ┌─ test/resources/files-to-check/cooltask.yaml:27:86
+   ┌─ test/resources/files-to-check/subdir/cooltask.yaml:27:86
    │
 27 │             echo "You can't expect to wield supreme executive power just 'cause some $watery_tart threw a sword at you!"
    │                                                                                      ^^^^^^^^^^^^

--- a/test/resources/patches/0001-Copy-tektontask-to-cooltask.patch
+++ b/test/resources/patches/0001-Copy-tektontask-to-cooltask.patch
@@ -4,15 +4,15 @@ Date: Thu, 20 Jun 2024 16:00:00 +0000
 Subject: [PATCH] Copy tektontask to cooltask
 
 ---
- test/resources/files-to-check/cooltask.yaml | 42 +++++++++++++++++++++
+ .../files-to-check/subdir/cooltask.yaml       | 42 +++++++++++++++++++
  1 file changed, 42 insertions(+)
- create mode 100644 test/resources/files-to-check/cooltask.yaml
+ create mode 100644 test/resources/files-to-check/subdir/cooltask.yaml
 
-diff --git a/test/resources/files-to-check/cooltask.yaml b/test/resources/files-to-check/cooltask.yaml
+diff --git a/test/resources/files-to-check/subdir/cooltask.yaml b/test/resources/files-to-check/subdir/cooltask.yaml
 new file mode 100644
 index 0000000..293c9b1
 --- /dev/null
-+++ b/test/resources/files-to-check/cooltask.yaml
++++ b/test/resources/files-to-check/subdir/cooltask.yaml
 @@ -0,0 +1,42 @@
 +apiVersion: tekton.dev/v1
 +kind: Task

--- a/test/resources/patches/generate.sh
+++ b/test/resources/patches/generate.sh
@@ -10,7 +10,8 @@ git worktree add -d "$WORKSPACE_DIR"
 trap 'git worktree remove --force "$WORKSPACE_DIR"' EXIT
 
 gen_patches() {
-    local tektontask=test/resources/files-to-check/tektontask.yaml
+    local tektontask_dir=test/resources/files-to-check
+    local tektontask=$tektontask_dir/tektontask.yaml
 
     cat << EOF >> "$tektontask"
 
@@ -27,13 +28,16 @@ EOF
     local add_script_ref
     add_script_ref=$(git rev-parse HEAD)
 
-    local cooltask=${tektontask%/*}/cooltask.yaml
+    local cooltask=${tektontask_dir}/cooltask.yaml
     git mv "$tektontask" "$cooltask"
     _commit_and_save_patch "Rename tektontask to cooltask"
 
+    local cooltask2=${tektontask_dir}/subdir/cooltask.yaml
     git reset HEAD^
     git checkout -- "$tektontask"
-    git add "$cooltask"
+    mkdir -p "$tektontask_dir/subdir"
+    cp "$tektontask" "$cooltask2"
+    git add "$cooltask2"
     _commit_and_save_patch "Copy tektontask to cooltask"
 
     git revert --no-edit "$add_script_ref"


### PR DESCRIPTION
Moving/copying a file into a directory that did not exist in the base ref would cause Checkton to fail when trying to copy the file. Create the parent directory if necessary.

<!-- Briefly explain what the PR does and why. -->

### Checklist

* [x] Add/update tests for your changes
* [x] Update CHANGELOG.md if your changes are relevant to users (<https://keepachangelog.com/en/1.1.0/#how>)
