### PR TITLE
Fix test data for sarif-fmt 0.5.0

### DIFF
--- a/test/resources/differential/diff-disabled/sarif-fmt.txt
+++ b/test/resources/differential/diff-disabled/sarif-fmt.txt
@@ -53,4 +53,4 @@ warning: Remove surrounding $() to avoid executing output (or use eval if intent
   = Defect reference: https://github.com/koalaman/shellcheck/wiki/SC2091
 
 warning: 5 warnings emitted
-error: 5 errors emitted
+error: 1 errors emitted

--- a/test/resources/differential/old-base/sarif-fmt.txt
+++ b/test/resources/differential/old-base/sarif-fmt.txt
@@ -35,4 +35,4 @@ warning: Remove surrounding $() to avoid executing output (or use eval if intent
   = Defect reference: https://github.com/koalaman/shellcheck/wiki/SC2091
 
 warning: 3 warnings emitted
-error: 3 errors emitted
+error: 1 errors emitted

--- a/test/resources/differential/undetected-copy/sarif-fmt.txt
+++ b/test/resources/differential/undetected-copy/sarif-fmt.txt
@@ -62,4 +62,4 @@ warning: watery_tart is referenced but not assigned.
    = Defect reference: https://github.com/koalaman/shellcheck/wiki/SC2154
 
 warning: 6 warnings emitted
-error: 6 errors emitted
+error: 1 errors emitted

--- a/test/resources/differential/undetected-rename/sarif-fmt.txt
+++ b/test/resources/differential/undetected-rename/sarif-fmt.txt
@@ -44,4 +44,4 @@ warning: watery_tart is referenced but not assigned.
    = Defect reference: https://github.com/koalaman/shellcheck/wiki/SC2154
 
 warning: 4 warnings emitted
-error: 4 errors emitted
+error: 1 errors emitted


### PR DESCRIPTION
Sarif-fmt 0.5.0 has landed in Fedora 40. It fixes the incorrect error count in the report.

<!-- Briefly explain what the PR does and why. -->

### Checklist

* [x] Add/update tests for your changes
* [n/a] Update CHANGELOG.md if your changes are relevant to users (<https://keepachangelog.com/en/1.1.0/#how>)
