### PR TITLE
Run the formatter at the correct ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-*Nothing yet.*
+### Fixed
+
+- Run the formatter (`csgrep` or `sarif-fmt`) at the correct git ref
+  - Before, Checkton would run the analysis at the specified commit but would
+    then run the formatter at HEAD, potentially resulting in incorrect output.
 
 ## [v0.2.1] - 2024-07-22
 

--- a/src/action.sh
+++ b/src/action.sh
@@ -7,6 +7,18 @@ if [[ -n "${GITHUB_WORKSPACE:-}" ]]; then
     git config --global --add safe.directory "$GITHUB_WORKSPACE"
 fi
 
+checkout() {
+    if ! stderr=$(git checkout "$@" 2>&1 1>/dev/null); then
+        printf "%s\n" "$stderr" >&2
+        return 1
+    fi
+}
+
+if [[ -n "${CHECKTON_DIFF_HEAD:-}" ]]; then
+    checkout "$CHECKTON_DIFF_HEAD"
+    trap 'checkout -' EXIT
+fi
+
 "$SCRIPTDIR"/differential-checkton.sh > .checkton.sarif
 
 exitcode=0


### PR DESCRIPTION
Previously, Checkton would correctly run ShellCheck at the specified CHECKTON_DIFF_HEAD (typically the latest commit in a pull request) but would then run the formatter (csgrep or sarif-fmt) at the current HEAD.

In action.sh, checkout CHECKTON_DIFF_HEAD to make sure the formatter runs at the correct ref as well.

<!-- Briefly explain what the PR does and why. -->

### Checklist

* **MISSING**  Add/update tests for your changes (no tests for action.sh yet, unfortunately)
* [x] Update CHANGELOG.md if your changes are relevant to users (<https://keepachangelog.com/en/1.1.0/#how>)
