### PR TITLE
Fix prepare-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -48,6 +48,10 @@ jobs:
             ${{ github.sha }}
             ${{ inputs.version }}
 
+      - name: Enable podman socket
+        run: |
+          systemctl --user start podman.socket
+
       - name: Generate SBOM
         uses: anchore/sbom-action@e11c554f704a0b820cbf8c51673f6945e0731532 # v0
         with:


### PR DESCRIPTION
The sbom-action started failing with:

    [0000] ERROR could not determine source: ...
      - docker: pull failed: Error response from daemon: manifest unknown
      - podman: podman not available: no host address ...
      ...

Starting the podman socket enables syft to resolve the image via podman

<!-- Briefly explain what the PR does and why. -->

### Checklist

* N/A Add/update tests for your changes
* N/A Update CHANGELOG.md if your changes are relevant to users (<https://keepachangelog.com/en/1.1.0/#how>)
